### PR TITLE
dgram regex doesn't account for newline after type

### DIFF
--- a/lib/Net/Async/Statsd/Server.pm
+++ b/lib/Net/Async/Statsd/Server.pm
@@ -171,7 +171,7 @@ sub on_recv {
 	)->on_done(sub {
 		my ($host, $port) = @_;
 		$self->debug_printf("UDP packet received from %s", join ':', $host, $port);
-		my ($k, $v, $type_char, $rate) = $dgram =~ /^([^:]+):([^|]+)\|([^|]+)(?:\|\@(.+))?$/ or warn "Invalid dgram: $dgram";
+		my ($k, $v, $type_char, $rate) = $dgram =~ /^([^:]+):([^|]+)\|([^|\n]+)(?:\|\@(.+))?$/ or warn "Invalid dgram: $dgram";
 		$rate ||= 1;
 		my $type = $self->type_for_char($type_char) // 'unknown';
 		$self->bus->invoke_event(


### PR DESCRIPTION
Some statsd clients add a newline after the type (e.g. Etsy::Statsd and Net::Statsite::Client on cpan). If that happens, `type_for_char()` will look for "c\n" which then becomes 'unknown' and metrics are lost. This change gets things working for me. Thanks!
