### PR TITLE
A couple of small fixes

### DIFF
--- a/examples/statsd-server.pl
+++ b/examples/statsd-server.pl
@@ -23,7 +23,7 @@ for(qw(count gauge timing)) {
 		$type => sub {
 			my ($ev, $k, $v) = @_;
 			if($type eq 'count') {
-				++$count{$k};
+				$count{$k} += $v;
 				say "$type - $k = " . $count{$k};
 			} elsif($type eq 'timing') {
 				unshift @{$timing{$type} ||= []}, $v;

--- a/lib/Net/Async/Statsd/Server.pm
+++ b/lib/Net/Async/Statsd/Server.pm
@@ -171,20 +171,22 @@ sub on_recv {
 	)->on_done(sub {
 		my ($host, $port) = @_;
 		$self->debug_printf("UDP packet received from %s", join ':', $host, $port);
-		my ($k, $v, $type_char, $rate) = $dgram =~ /^([^:]+):([^|]+)\|([^|]+)(?:\|\@(.+))?/ or warn "Invalid dgram: $dgram";
-		$rate ||= 1;
-		my $type = $self->type_for_char($type_char) // 'unknown';
-		$self->bus->invoke_event(
-			$type => ($k, $v, $rate, $host, $port)
-		);
-		$self->debug_printf(
-			"dgram %s from %s: %s => %s (%s)",
-			$dgram,
-			join(':', $host, $port),
-			$k,
-			$v,
-			$type
-		);
+		foreach my $stat (split m/\n/, $dgram) {
+			my ($k, $v, $type_char, $rate) = $stat =~ /^([^:]+):([^|]+)\|([^|]+)(?:\|\@(.+))?/ or warn "Invalid dgram: $stat";
+			$rate ||= 1;
+			my $type = $self->type_for_char($type_char) // 'unknown';
+			$self->bus->invoke_event(
+				$type => ($k, $v, $rate, $host, $port)
+			);
+			$self->debug_printf(
+				"dgram %s from %s: %s => %s (%s)",
+				$stat,
+				join(':', $host, $port),
+				$k,
+				$v,
+				$type
+			);
+		}
 	});
 }
 


### PR DESCRIPTION
 * Make example server cope with counter increments by values other than 1

 * Make NaStatsd::Server implementation split multiple stats out of incoming packets

Admittedly on this second change, the `->bus` emits them as multiple separate events and loses the atomicity of the UDP packet, even though they'll still happen within the same event loop tick. If this is a concern it may warrant adding something of a list structure to the emitted event for multiple stats in one packet. I'll leave that to your decision.